### PR TITLE
Update init script to get again /var/log/fail2ban.log

### DIFF
--- a/etc/init.d/fail2ban
+++ b/etc/init.d/fail2ban
@@ -45,7 +45,7 @@ start_service() {
 	procd_set_param file ${CONFDIR}/*.conf
 	procd_set_param file ${CONFDIR}/*.local
 
-	procd_set_param command /usr/bin/fail2ban-server -xf --logtarget=syslog -p "${RUNDIR}/fail2ban.pid" -s "${RUNDIR}/fail2ban.sock" start
+	procd_set_param command /usr/bin/fail2ban-server -xf -p "${RUNDIR}/fail2ban.pid" -s "${RUNDIR}/fail2ban.sock" start
 	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
 	procd_close_instance
 }


### PR DESCRIPTION
Update init script to get again /var/log/fail2ban.log from /etc/fail2ban/fail2ban.conf and .local
removed hardcoded --logtarget=syslog which forced the syslog logging